### PR TITLE
Raise InternalError if pyetcd raises EtcdKeyNotFound

### DIFF
--- a/etcdb/lock.py
+++ b/etcdb/lock.py
@@ -35,7 +35,7 @@ class Lock(object):
     def acquire(self, timeout=1):
         """Get a lock
 
-        :param timeout: Timout to acquire a lock.
+        :param timeout: Timeout to acquire a lock.
         :type timeout: int
         :raise InternalError: This class shouldn't be used directly and
             if user doesn't set lock_prefix the method should
@@ -77,9 +77,12 @@ class Lock(object):
 
         if self._id:
             key += "/%s" % self._id
-
-        self._etcd_client.delete(key)
-        active_children()
+        try:
+            self._etcd_client.delete(key)
+        except EtcdKeyNotFound as err:
+            raise InternalError('Failed to release a lock: %s' % err)
+        finally:
+            active_children()
 
     def readers(self):
         """Get list of reader locks.

--- a/tests/unit/lock/test_init.py
+++ b/tests/unit/lock/test_init.py
@@ -1,0 +1,18 @@
+import pytest
+
+from etcdb import InternalError
+from etcdb.lock import Lock
+
+
+def test_lock_sets_attributes(etcdb_connection):
+    lock = Lock(etcdb_connection.client, 'foo', 'bar', lock_id='some_lock')
+    assert lock._db == 'foo'
+    assert lock._tbl == 'bar'
+    assert lock._id == 'some_lock'
+    assert lock._lock_prefix is None
+
+
+def test_acquire_raises(etcdb_connection):
+    l = Lock(etcdb_connection.client, 'foo', 'bar', lock_id='some_lock')
+    with pytest.raises(InternalError):
+        l.acquire()

--- a/tests/unit/lock/test_release.py
+++ b/tests/unit/lock/test_release.py
@@ -1,0 +1,19 @@
+import mock
+import pytest
+from pyetcd import EtcdKeyNotFound
+
+from etcdb import InternalError
+from etcdb.lock import Lock
+
+
+@mock.patch('etcdb.lock.active_children')
+def test_release_raises_internal(mock_active_children, etcdb_connection):
+    mock_delete = mock.Mock()
+    mock_delete.side_effect = EtcdKeyNotFound
+    etcdb_connection.client.delete = mock_delete
+
+    lock = Lock(etcdb_connection.client, 'foo', 'bar', lock_id='some_lock')
+    with pytest.raises(InternalError):
+        lock.release()
+    mock_active_children.assert_called_once_with()
+


### PR DESCRIPTION
Whatever grabs a lock must be one to release it.
If lock doesn't exist pyetcd will raise EtcdKeyNotFound exception.
etcdb should raise InternalError in that case